### PR TITLE
Update to fix release mode issue

### DIFF
--- a/app/src/org/commcare/activities/CaptureRdtActivity.java
+++ b/app/src/org/commcare/activities/CaptureRdtActivity.java
@@ -70,6 +70,7 @@ public class CaptureRdtActivity extends AppCompatActivity {
 
                 arguments.putBoolean(CaptureFragment.IncludeTestAreaImage, true);
                 arguments.putBoolean(CaptureFragment.ReturnInterpretedImage, true);
+                arguments.putBoolean(CaptureFragment.UseLocal, true);
 
                 fragment.setArguments(arguments);
             }


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This change updates the Audere HealthPulse Mobile SDK for Android integration with the eCHIS CommCare app to prevent an issue that occurs in release mode builds.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Verified locally on a release build that RDT Capture flow doesn't hang.